### PR TITLE
Update eval.py - minor change

### DIFF
--- a/src/databench_eval/eval.py
+++ b/src/databench_eval/eval.py
@@ -16,6 +16,7 @@ class Evaluator:
         self.qa = qa if qa is not None else load_qa(**kwargs)
 
     def default_compare(self, value, truth, semantic):
+        semantic = semantic.strip()
         if semantic == "boolean":
             return str(value) == str(truth)
         elif semantic == "category":


### PR DESCRIPTION
There is a question in the `dev_qa` dataframe that has the `answer_type(semantic)`, which is `"  category"`. 

Since the if-else conditions of the semantic do not consider whitespace. Therefore, it will result in the following exception during the evaluation script's run : 

```
Semantic not supported: "  category"
```